### PR TITLE
Add placeable exception for zh-TW

### DIFF
--- a/.github/scripts/validate_json.py
+++ b/.github/scripts/validate_json.py
@@ -59,6 +59,7 @@ def main():
         for fn, fn_issues in issues.items():
             for i in fn_issues:
                 print(f"Error in {fn}: {i}")
+                sys.exit(1)
     else:
         print("No issues found.")
 

--- a/.github/scripts/validate_json.py
+++ b/.github/scripts/validate_json.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import argparse
 import json
 import os
+import sys
 
 
 def main():

--- a/l10n/exceptions/mozorg.json
+++ b/l10n/exceptions/mozorg.json
@@ -49,7 +49,9 @@
           "en/footer.ftl:footer-follow-firefox",
           "en/footer.ftl:footer-follow-mozilla",
           "en/mozorg/newsletters.ftl:newsletters-beta-news"
-      ]
+      ],
+      "zh-TW": [
+          "en/mozorg/about/history.ftl:history-the-history-of-firefox-and"
     },
     "strings": []
   },

--- a/l10n/exceptions/mozorg.json
+++ b/l10n/exceptions/mozorg.json
@@ -52,6 +52,7 @@
       ],
       "zh-TW": [
           "en/mozorg/about/history.ftl:history-the-history-of-firefox-and"
+      ],  
     },
     "strings": []
   },

--- a/l10n/exceptions/mozorg.json
+++ b/l10n/exceptions/mozorg.json
@@ -52,7 +52,7 @@
       ],
       "zh-TW": [
           "en/mozorg/about/history.ftl:history-the-history-of-firefox-and"
-      ],  
+      ]
     },
     "strings": []
   },


### PR DESCRIPTION
This is to resolve the issue of using a customized link in zh-TW: https://pontoon.mozilla.org/zh-TW/mozillaorg/en/mozorg/about/history.ftl/?string=219623