### PR TITLE
Add HTML exceptions for Android to ar, el, fa, id, it, my, sq locales

### DIFF
--- a/l10n/exceptions/firefox_android.json
+++ b/l10n/exceptions/firefox_android.json
@@ -1,8 +1,26 @@
 {
   "HTML": {
     "locales": {
+      "ar": [
+        "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_unknown_host_message"
+      ],
+      "el": [
+        "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_unknown_protocol_message"
+      ],
+      "fa": [
+        "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_redirect_loop_message"
+      ],
+      "id": [
+        "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_file_not_found_message"
+      ],
       "it": [
         "app/src/main/res/values/strings.xml:your_rights_content5"
+      ],
+      "my": [
+        "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_port_blocked_message"
+      ],
+      "sq": [
+        "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_net_timeout_message"
       ]
     },
     "strings": []

--- a/l10n/exceptions/firefox_android.json
+++ b/l10n/exceptions/firefox_android.json
@@ -4,6 +4,9 @@
       "ar": [
         "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_unknown_host_message"
       ],
+      "cs": [
+        "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_redirect_loop_message"
+      ],
       "el": [
         "components/browser/errorpages/src/main/res/values/strings.xml:mozac_browser_errorpages_unknown_protocol_message"
       ],


### PR DESCRIPTION
This PR adds HTML exemptions for certain strings in the above locales to the Firefox Android linter exemptions file.