### PR TITLE
Add exceptions for `sq`

### DIFF
--- a/l10n/exceptions/mozorg.json
+++ b/l10n/exceptions/mozorg.json
@@ -20,6 +20,14 @@
         "en/firefox/features/translate.ftl:features-translate-with-the-to",
         "en/firefox/privacy/passwords.ftl:privacy-passwords-in-general-the"
       ],
+       "sq": [
+        "en/privacy/faq.ftl:privacy-faq-mozilla-doesnt-know-as-much",
+        "en/firefox/browsers/history/what-is-a-browser.ftl:what-is-a-browser-when-the-web-browser",
+        "en/firefox/features/fingerprinting.ftl:features-fingerprinting-the-practice-of",
+        "en/products/vpn/more/vpn-or-proxy.ftl:vpn-or-proxy-the-most-important",
+        "en/products/vpn/more/when-to-use-a-vpn.ftl:vpn-when-to-use-have-you-ever",
+        "en/products/vpn/more/when-to-use-a-vpn.ftl:vpn-when-to-use-the-most-important" 
+      ],
       "zh-TW": [
         "en/mozorg/about/history.ftl:history-the-history-of-firefox-and",
         "en/mozorg/newsletters.ftl:newsletters-read-all-about-it-in-our-newsletter"


### PR DESCRIPTION
After discussing with `sq` locale manager, these strings have no workaround and are best to add to the exception list.