### PR TITLE
Add entry for `fr`; remove entries for `sk`

### DIFF
--- a/l10n/exceptions/relay.json
+++ b/l10n/exceptions/relay.json
@@ -26,9 +26,8 @@
   },
   "placeables": {
     "locales": {
-      "sk": [
-        "profile.ftl:profile-promo-email-blocking-label-forwarding",
-        "whatsnew.ftl:whatsnew-feature-alias-to-mask-snippet"
+      "fr": [
+        "phones.ftl:phone-onboarding-step3-body"
       ]
     },
     "strings": []

--- a/l10n/exceptions/relay.json
+++ b/l10n/exceptions/relay.json
@@ -1,6 +1,10 @@
 {
   "HTML": {
-    "locales": {},
+     "locales": {
+      "fr": [
+        "phones.ftl:phone-onboarding-step3-body"
+      ]
+    },
     "strings": []
   },
   "data-l10n-names": {
@@ -25,11 +29,7 @@
     "strings": []
   },
   "placeables": {
-    "locales": {
-      "fr": [
-        "phones.ftl:phone-onboarding-step3-body"
-      ]
-    },
+    "locales": {},
     "strings": []
   }
 }


### PR DESCRIPTION
Added one for French:
https://github.com/mozilla-l10n/mozl10n-linter/actions/runs/15456525634

Removed entries for Slovak as the revised translations no longer needed exceptions.