### PR TITLE
Fix Fluent checks silently skipping localized strings in fluent_l10n linter

### DIFF
--- a/l10n/fluent_l10n.py
+++ b/l10n/fluent_l10n.py
@@ -406,7 +406,6 @@ class QualityCheck:
                 if ignoreString(locale, "general", string_id):
                     continue
 
-                translation = locale_translations[string_id]
                 if not isinstance(translation, str):
                     continue
 
@@ -418,7 +417,7 @@ class QualityCheck:
                 # Check for empty translation, or translations with just line
                 # breaks
                 if "".join(translation.splitlines()) == "":
-                    reference_string = reference_data.get(string_id, "")
+                    reference_string = reference_data[string_id]["value"]
                     error_msg = (
                         f"{string_id} is empty\n"
                         f"  Translation: {translation}\n"
@@ -460,7 +459,7 @@ class QualityCheck:
                     serializer = FluentSerializer()
                     message_id = string_id.split(":")[1]
                     l10n_select.visit(parse(f"{message_id} = {translation}"))
-                    reference_string = reference_data.get(string_id, "")
+                    reference_string = reference_data[string_id]["value"]
                     ref_select.visit(parse(f"{message_id} = {reference_string}"))
 
                     for select_var in l10n_select.select_vars:
@@ -530,7 +529,7 @@ class QualityCheck:
                 if ignoreString(locale, "data-l10n-names", string_id):
                     continue
 
-                translation = locale_translations[string_id]
+                translation = locale_translations[string_id]["value"]
                 if not isinstance(translation, str):
                     continue
                 matches_iterator = datal10n_pattern.finditer(translation)
@@ -567,7 +566,7 @@ class QualityCheck:
                 if ignoreString(locale, "placeables", string_id):
                     continue
 
-                translation = locale_translations[string_id]
+                translation = locale_translations[string_id]["value"]
                 if not isinstance(translation, str):
                     continue
                 matches_iterator = placeable_pattern.finditer(translation)

--- a/l10n/fluent_l10n.py
+++ b/l10n/fluent_l10n.py
@@ -417,7 +417,7 @@ class QualityCheck:
                 # Check for empty translation, or translations with just line
                 # breaks
                 if "".join(translation.splitlines()) == "":
-                    reference_string = reference_data[string_id]["value"]
+                    reference_string = reference_data.get(string_id, {}).get("value", "")
                     error_msg = (
                         f"{string_id} is empty\n"
                         f"  Translation: {translation}\n"
@@ -459,7 +459,7 @@ class QualityCheck:
                     serializer = FluentSerializer()
                     message_id = string_id.split(":")[1]
                     l10n_select.visit(parse(f"{message_id} = {translation}"))
-                    reference_string = reference_data[string_id]["value"]
+                    reference_string = reference_data.get(string_id, {}).get("value", "")
                     ref_select.visit(parse(f"{message_id} = {reference_string}"))
 
                     for select_var in l10n_select.select_vars:
@@ -529,7 +529,7 @@ class QualityCheck:
                 if ignoreString(locale, "data-l10n-names", string_id):
                     continue
 
-                translation = locale_translations[string_id]["value"]
+                translation = locale_translations.get(string_id, {}).get("value", "")
                 if not isinstance(translation, str):
                     continue
                 matches_iterator = datal10n_pattern.finditer(translation)
@@ -566,7 +566,7 @@ class QualityCheck:
                 if ignoreString(locale, "placeables", string_id):
                     continue
 
-                translation = locale_translations[string_id]["value"]
+                translation = locale_translations.get(string_id, {}).get("value", "")
                 if not isinstance(translation, str):
                     continue
                 matches_iterator = placeable_pattern.finditer(translation)


### PR DESCRIPTION
A refactor to moz.l10n changed the data model for translations from a plain string to a dict. Some parts of the fluent_l10n linter were updated to adapt to the change but other individual string level checks didn't, causing no strings to be checked resulting in the linter erroneously succeeding silently. 

This update updates the FxA linter's individual string level checks to the new model. A [run](https://github.com/bcolsson/mozl10n-linter/actions/runs/29612363206) catches 52 previously uncaught errors.